### PR TITLE
added mean, min, and max feature extraction methods

### DIFF
--- a/feat/data.py
+++ b/feat/data.py
@@ -278,16 +278,73 @@ class Fex(DataFrame):
             out['weights'] = self.__class__(pd.DataFrame(out['decomposition_object'].components_, index=com_names, columns=self.columns), sampling_freq=None).T
         return out
 
+    def extract_mean(self, by=[], *args, **kwargs):
+        """ Extract mean of each feature
+        Args:
+            by: List of string(s) specifying the columns that means
+                will be extracted along (e.g. subject, trial, etc.). Defaults
+                to an empty list, which returns means across all observations.
+        Returns:
+            mean: list of means for each feature
+
+
+        """
+        assert not isinstance(by, str), "'by' must be a list"
+        if len(by)>0:
+            feats = pd.DataFrame(self.groupby(by).mean())
+        else:
+            feats = pd.DataFrame(self.mean()).transpose()
+            feats.columns = 'mean_' + feats.columns
+        return self.__class__(feats)
+
+    def extract_min(self, by=[], *args, **kwargs):
+        """ Extract minimum of each feature
+        Args:
+            by: List of string(s) specifying the columns that minimums
+                will be extracted along (e.g. subject, trial, etc.). Defaults
+                to an empty list, which returns minimums across all observations.
+        Returns:
+            min: list of minimum values for each feature
+
+
+        """
+        assert not isinstance(by, str), "'by' must be a list"
+        if len(by)>0:
+            feats = pd.DataFrame(self.groupby(by).min())
+        else:
+            feats = pd.DataFrame(self.min()).transpose()
+        feats.columns = 'min_' + feats.columns
+        return self.__class__(feats)
+
+    def extract_max(self, by=[], *args, **kwargs):
+        """ Extract maximum of each feature
+        Args:
+            by: List of string(s) specifying the columns that maximums
+                will be extracted along (e.g. subject, trial, etc.). Defaults
+                to an empty list, which returns maximums across all observations.
+        Returns:
+            max: list of maximum values for each feature
+
+
+        """
+        assert not isinstance(by, str), "'by' must be a list"
+        if len(by)>0:
+            feats = pd.DataFrame(self.groupby(by).max())
+        else:
+            feats = pd.DataFrame(self.max()).transpose()
+        feats.columns = 'max_' + feats.columns
+        return self.__class__(feats)
+
     def extract_boft(self, min_freq=.06, max_freq=.66, bank=8, *args, **kwargs):
         """ Extract Bag of Temporal features
-        Args: 
+        Args:
             min_freq: maximum frequency of temporal filters
             max_freq: minimum frequency of temporal filters
             bank: number of temporal filter banks, filters are on exponential scale
 
         Returns:
             wavs: list of Morlet wavelets with corresponding freq
-            hzs:  list of hzs for each Morlet wavelet   
+            hzs:  list of hzs for each Morlet wavelet
 
 
         """

--- a/feat/tests/test_feat.py
+++ b/feat/tests/test_feat.py
@@ -23,7 +23,7 @@ def test_fex(tmpdir):
         def test1(self):
             with self.assertRaises(KeyError):
                 Fex(read_facet(filename, features=['NotHere']), sampling_freq=30)
-    
+
     # Test length
     assert len(dat)==519
 
@@ -63,22 +63,27 @@ def test_fex(tmpdir):
     filters, histograms = 8, 12
     assert facet_filled.extract_boft().shape[1]==facet.columns.shape[0] * filters * histograms
 
+    # Test mean, min, and max Features Extraction
+    assert isinstance(facet_filled.extract_mean(), Facet)
+    assert isinstance(facet_filled.extract_min(), Facet)
+    assert isinstance(facet_filled.extract_max(), Facet)
+
     # Test if a method returns subclass.
     facet = facet.downsample(target=10,target_type='hz')
     assert isinstance(facet,Facet)
 
-    ### Test Openface importer and subclass ### 
-    
+    ### Test Openface importer and subclass ###
+
     # For OpenFace data file
     filename = join(get_test_data_path(), 'OpenFace_Test.csv')
     openface = Fex(read_openface(filename), sampling_freq=30)
-    
+
     # Test KeyError
     class MyTestCase(unittest.TestCase):
         def test1(self):
             with self.assertRaises(KeyError):
                 Fex(read_openface(filename, features=['NotHere']), sampling_freq=30)
-    
+
 
     # Test length
     assert len(openface)==100
@@ -97,7 +102,7 @@ def test_fex(tmpdir):
     data_bad = dat.iloc[:,0:10]
     with pytest.raises(Exception):
         _check_if_fex(data_bad, imotions_columns)
-    
+
     # Check if file has too many columns
     data_bad = dat.copy()
     data_bad['Test'] = 0
@@ -152,5 +157,3 @@ def test_fex(tmpdir):
                           n_components=n_components)
     assert n_components == stats['components'].shape[1]
     assert n_components == stats['weights'].shape[1]
-
-


### PR DESCRIPTION
Let me know what you all think of this method of feature extraction. The output format is the same as the boft extractor (1 row, and a column for each feature), and specifying the 'by' argument allows users to group observations by other features in the data before summarizing (e.g. by subjects, trials, or whatever). By default, the functions will summarize data across all rows. 

This is all default pandas functionality too, so it is quick and easy. 