### PR TITLE
Facet cleanup

### DIFF
--- a/feat/tests/test_feat.py
+++ b/feat/tests/test_feat.py
@@ -14,7 +14,11 @@ from nltools.data import Adjacency
 import unittest
 
 def test_fex(tmpdir):
-    # For iMotions-FACET data file
+    # For iMotions-FACET data files
+    # test reading iMotions file < version 6
+    dat = Fex(read_facet(join(get_test_data_path(), 'iMotions_Test_v2.txt')), sampling_freq=30)
+
+    # test reading iMotions file > version 6
     filename = join(get_test_data_path(), 'iMotions_Test.txt')
     dat = Fex(read_facet(filename), sampling_freq=30)
 


### PR DESCRIPTION
removed whitespaces and 'Evidence', 'Degrees' words from read_facet. 
added reading timestamps. and FaceRect(boundingbox)
still ignores other text info (study name, gender etc) because it messes with methods. 
added versioning to read_facet. files from iMotions-FACET version < 6
will not return Confusion, Frustration (because they don't exist) but will still be readable. 
added tests